### PR TITLE
1.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 .pub-cache/
 .pub/
 /build/
+coverage/
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,0 +1,5 @@
+class Constants {
+  static const String FAMILY_STORE_URL =
+      'https://family-store-dev.vercel.app/apps/14';
+  static const String DEFAULT_USERNAME = 'Użytkownik bez nazwy';
+}

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,5 +1,5 @@
 class Constants {
   static const String FAMILY_STORE_URL =
-      'https://family-store-dev.vercel.app/apps/14';
+      'https://family-store.vercel.app/apps/14';
   static const String DEFAULT_USERNAME = 'Użytkownik bez nazwy';
 }

--- a/lib/core/models/product.dart
+++ b/lib/core/models/product.dart
@@ -81,4 +81,10 @@ class Product {
     }
     return '$displayedQuantity $quantityUnit';
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != Product) return false;
+    return id == (other as Product).id;
+  }
 }

--- a/lib/core/updater.dart
+++ b/lib/core/updater.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:zakupyapp/constants.dart';
 import 'package:zakupyapp/storage/database_manager.dart';
 import 'package:zakupyapp/storage/storage_manager.dart';
 
@@ -15,7 +16,7 @@ class Updater {
   Future<AppRelease> getLatestRelease() async {
     AppRelease latestRelease = await _db.getLatestRelease();
     if (SM.getUseFamilyStore()) {
-      latestRelease.downloadUrl = 'https://family-store-dev.vercel.app/apps/14';
+      latestRelease.downloadUrl = Constants.FAMILY_STORE_URL;
     }
     return latestRelease;
   }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,10 +1,12 @@
+import 'package:diffutil_sliverlist/diffutil_sliverlist.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:provider/provider.dart';
 
 import 'package:zakupyapp/core/models/product.dart';
-import 'package:zakupyapp/core/shopping_list.dart';
+import 'package:zakupyapp/core/shopping_list_manager.dart';
 import 'package:zakupyapp/core/updater.dart';
+import 'package:zakupyapp/storage/storage_manager.dart';
 import 'package:zakupyapp/widgets/drawer/main_drawer.dart';
 import 'package:zakupyapp/widgets/home/product_card/product_card.dart';
 import 'package:zakupyapp/widgets/shared/update_dialog.dart';
@@ -17,213 +19,167 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  ShoppingList shoppingList = ShoppingList();
-  Updater updater = Updater();
-  bool isDataReady = false;
+  final ShoppingListManager shoppingListManager =
+      ShoppingListManager(SM.getShoppingListId());
+  final Updater updater = Updater();
+
+  List<Widget> itemsToDisplay = [];
+
+  bool isFirstLoadDone = false;
 
   Product? editedProduct;
   bool isAddingProduct = false;
 
-  final animatedListKey = GlobalKey<AnimatedListState>();
+  /// Updates [editedProduct] & [isAddingProduct] flags and resets
+  /// itemsToDisplay list to remove any editors. Doesn't call setState
+  void hideEditor() {
+    isAddingProduct = false;
+    editedProduct = null;
+    setItemsToDisplay(shoppingListManager.filteredProducts);
+  }
+
+  /*
+  //
+  ====== CARD CALLBACKS ======
+  //
+   */
 
   void addProductFunc() {
     if (!isAddingProduct) {
-        setState(() {
-          editedProduct = null;
-          isAddingProduct = true;
-        });
-        animatedListKey.currentState?.insertItem(0);
+      setState(() {
+        editedProduct = null;
+        isAddingProduct = true;
+        setItemsToDisplay(shoppingListManager.filteredProducts);
+      });
     }
   }
 
-  VoidCallback getEditProductFunc(Product product) {
-    return () {
-      if (product.isEditable)
-        setState(() {
-          isAddingProduct = false;
-          editedProduct = product;
-        });
-    };
+  void editProductFunc(Product product) {
+    if (product.isEditable)
+      setState(() {
+        isAddingProduct = false;
+        editedProduct = product;
+        setItemsToDisplay(shoppingListManager.filteredProducts);
+      });
   }
 
-  VoidCallback getDeleteProductFunc(Product product) =>
-      () async => await showDialog(
-            context: context,
-            builder: (context) {
-              return AlertDialog(
-                title: Text('Usuń produkt'),
-                content: Text('Czy na pewno chcesz usunąć: ${product.name}?'),
-                actions: <Widget>[
-                  TextButton(
-                    child: Text('Anuluj'),
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                  TextButton(
-                    child: Text('Tak'),
-                    onPressed: () async {
-                      await shoppingList.removeProduct(product);
-                      Navigator.of(context).pop();
-                      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                        content: Text('Usunięto wybrany produkt'),
-                      ));
-                    },
-                  ),
-                ],
-              );
-            },
-          );
+  Future<void> deleteProductFunc(Product product) async {
+    await shoppingListManager.removeProduct(product);
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text('Usunięto wybrany produkt'),
+    ));
+  }
 
-  VoidCallback getAddBuyerFunc(Product product) => () async {
-        bool? actionResult = await shoppingList.toggleProductBuyer(product);
-        // no action was taken
-        if (actionResult == null) {
-          return;
-        }
-        // buyer added
-        if (actionResult) {
-          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-            content: Text('Dodano deklarację kupna'),
-          ));
-        }
-        // buyer removed
-        else {
-          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-            content: Text('Usunięto deklarację kupna'),
-          ));
-        }
-      };
+  Future<void> addBuyerFunc(Product product) async {
+    bool? actionResult = await shoppingListManager.toggleProductBuyer(product);
+    // no action was taken
+    if (actionResult == null) {
+      return;
+    }
+    // buyer added
+    if (actionResult) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text('Dodano deklarację kupna'),
+      ));
+    }
+    // buyer removed
+    else {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text('Usunięto deklarację kupna'),
+      ));
+    }
+  }
 
   Future<void> confirmEditProductFunc(Product product) async {
-    setState(() {
-      editedProduct = null;
-      isAddingProduct = false;
-    });
-    await shoppingList.storeProduct(product);
+    hideEditor();
+    await shoppingListManager.storeProduct(product);
   }
 
   void cancelEditProductFunc() {
-    setState(() {
-      editedProduct = null;
-      isAddingProduct = false;
-    });
+    setState(() => hideEditor());
   }
 
+  /*
+  //
+  ====== FILTERS ======
+  //
+   */
+
   void toggleBuyerFilter() {
-    setState(() {
-      // cancel editing when filters change
-      editedProduct = null;
-      isAddingProduct = false;
-      // toggle filter
-      shoppingList.showOnlyDeclaredByUser =
-          !shoppingList.showOnlyDeclaredByUser;
-    });
+    // cancel editing when filters change
+    hideEditor();
+    // toggle filter
+    shoppingListManager.showOnlyDeclaredByUser =
+        !shoppingListManager.showOnlyDeclaredByUser;
   }
 
   void setShopFilter(String filter) {
-    setState(() {
-      // cancel editing when filters change
-      editedProduct = null;
-      isAddingProduct = false;
-      // apply filter
-      shoppingList.filteredShop = filter;
-    });
+    // cancel editing when filters change
+    hideEditor();
+    // apply filter
+    shoppingListManager.filteredShop = filter;
   }
 
-  /// Returns a list of widgets to put inside the main ListView.
-  List<Widget> getItemsToDisplay() {
+  /*
+  //
+  ====== UPDATING SHOPPING LIST ======
+  //
+   */
+
+  /// Updates [itemsToDisplay] which stores a list of widgets to put inside the
+  /// main list view.
+  void setItemsToDisplay(List<Product> products) {
     // create actual widgets from products
-    final products = shoppingList.getProductsToDisplay();
-    final result = products.map(wrapProductWithCard).toList();
+    final result = products.map(wrapProductWithWidget).toList();
 
     // handle adding product
     if (isAddingProduct) {
       // adding product key
-      final productCard = ProductCard(
-        key: Key('adding'),
-        product: null,
-        editFunc: () {},
-        deleteFunc: () {},
-        addBuyerFunc: () {},
-        onConfirmEdit: confirmEditProductFunc,
-        onCancelEdit: cancelEditProductFunc,
-        isEditing: true,
-      );
+      final productCard = ProductCard.emptyEditor(
+          newProductId: Product.generateProductId(),
+          onConfirmEdit: confirmEditProductFunc,
+          onCancelEdit: cancelEditProductFunc);
       result.insert(0, productCard);
     }
-
     // handle editing product
     else if (editedProduct != null) {
       // substitute one of the product cards for the editable version
       final product = editedProduct!;
       int editedProductIndex = products.indexOf(product);
-      result[editedProductIndex] = wrapProductWithCard(
+      result[editedProductIndex] = wrapProductWithWidget(
         product,
         isEditing: true,
       );
     }
-    return result;
+    itemsToDisplay = result;
   }
 
-  ProductCard wrapProductWithCard(Product product, {bool isEditing = false}) {
+  Widget wrapProductWithWidget(Product product, {bool isEditing = false}) {
     return ProductCard(
       key: Key(product.id),
       product: product,
-      editFunc: getEditProductFunc(product),
-      deleteFunc: getDeleteProductFunc(product),
-      addBuyerFunc: getAddBuyerFunc(product),
+      editFunc: () => editProductFunc(product),
+      deleteFunc: deleteProductFunc,
+      addBuyerFunc: () => addBuyerFunc(product),
       onConfirmEdit: confirmEditProductFunc,
       onCancelEdit: cancelEditProductFunc,
       isEditing: isEditing,
     );
   }
 
-  /// different body depending on
-  /// [isDataReady] & [shoppingList.isInitialised] values
-  Widget getBody() {
-    // if shoppingListId is not specified, display an info on it
-    if (!shoppingList.isInitialised)
-      return Center(
-          child: Text(
-        'Nie wybrano żadnej listy zakupów. Możesz to zrobić w Ustawieniach',
-        textAlign: TextAlign.center,
-      ));
-
-    // if shoppingListId is specified, but the data is loading, display
-    // a circular progress indicator
-    if (!isDataReady) return Center(child: CircularProgressIndicator());
-
-    final itemsToDisplay = getItemsToDisplay();
-
-    // if data is ready, but there are no items to display, show an info on it
-    if (itemsToDisplay.isEmpty)
-      return Center(
-          child: Text(
-        'Brak przedmiotów do wyświetlenia',
-        textAlign: TextAlign.center,
-      ));
-
-    // otherwise, display the shopping list
-    return Scrollbar(
-      child: Provider<ShoppingList>(
-        create: (context) => shoppingList,
-        child: AnimatedList(
-          key: animatedListKey,
-          padding: EdgeInsets.all(5.0),
-          initialItemCount: itemsToDisplay.length,
-          itemBuilder: (context, index, animation) => SizeTransition(
-            sizeFactor: animation,
-            axisAlignment: 1,
-            child: Container(
-              width: double.infinity, // otherwise cards shrink in width
-              child: itemsToDisplay[index],
-            ),
-          ),
-        ),
-      ),
-    );
+  /// Will run every time products list is updated
+  void onProductsUpdated(List<Product> snapshot) {
+    setState(() {
+      isFirstLoadDone = true;
+      setItemsToDisplay(snapshot);
+    });
   }
+
+  /*
+  //
+  ====== LIFECYCLE METHODS ======
+  //
+   */
 
   @override
   void initState() {
@@ -240,22 +196,80 @@ class _HomeScreenState extends State<HomeScreen> {
             )));
 
     // initialise the shopping list
-    if (shoppingList.isInitialised) {
-      // on new products refresh the view as well as update isDataReady flag
-      // on default shops received refresh the view so that the filters work
-      shoppingList.startListening(
-        onProductsUpdatedCallback: () {
-          if (!isDataReady) setState(() => isDataReady = true);
-        },
-        onDefaultShopsReveivedCallback: () => setState(() {}),
-      );
+    if (shoppingListManager.isInitialised) {
+      shoppingListManager.onProductsUpdated = onProductsUpdated;
+      shoppingListManager.onDefaultShopsReveived = () => setState(() {
+            // empty setState to refresh filters with contents of
+            // shoppingListManager.availableShops
+          });
+      shoppingListManager.subscribe();
     }
   }
 
   @override
   void dispose() {
-    shoppingList.stopListening();
+    shoppingListManager.unsubscribe();
     super.dispose();
+  }
+
+  /*
+  //
+  ====== WIDGET TREE ======
+  //
+   */
+
+  /// different body depending on [isFirstLoadDone] &
+  /// [shoppingListManager.isInitialised] values
+  Widget getBody() {
+    // if shoppingListId is not specified, display an info on it
+    if (!shoppingListManager.isInitialised)
+      return Center(
+          child: Text(
+        'Nie wybrano żadnej listy zakupów. Możesz to zrobić w Ustawieniach',
+        textAlign: TextAlign.center,
+      ));
+
+    // if shoppingListId is specified, but the data is loading, display
+    // a circular progress indicator
+    if (!isFirstLoadDone) return Center(child: CircularProgressIndicator());
+
+    // if data is ready, but there are no items to display, show an info on it
+    if (itemsToDisplay.isEmpty)
+      return Center(
+          child: Text(
+        'Brak przedmiotów do wyświetlenia',
+        textAlign: TextAlign.center,
+      ));
+
+    // otherwise, display the shopping list
+    return Provider<ShoppingListManager>(
+      create: (context) => shoppingListManager,
+      child: CustomScrollView(
+        slivers: [
+          DiffUtilSliverList.fromKeyedWidgetList(
+            children: List.from(itemsToDisplay),
+            insertAnimationBuilder: (context, animation, child) =>
+                FadeTransition(
+              opacity: animation,
+              child: SizeTransition(
+                sizeFactor: animation,
+                axisAlignment: 1,
+                child: child,
+              ),
+            ),
+            removeAnimationBuilder: (context, animation, child) =>
+                FadeTransition(
+              opacity: animation,
+              child: SizeTransition(
+                sizeFactor: animation,
+                axisAlignment: 1,
+                child: child,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -264,13 +278,13 @@ class _HomeScreenState extends State<HomeScreen> {
       drawer: MainDrawer(),
       appBar: AppBar(
         title: Text('Lista zakupów'),
-        actions: !isDataReady
+        actions: !isFirstLoadDone
             ? []
             : <Widget>[
                 IconButton(
                   icon: Icon(
                     Icons.shopping_cart_checkout,
-                    color: shoppingList.showOnlyDeclaredByUser
+                    color: shoppingListManager.showOnlyDeclaredByUser
                         ? Colors.black
                         : Colors.deepOrange[900],
                   ),
@@ -279,12 +293,12 @@ class _HomeScreenState extends State<HomeScreen> {
                 PopupMenuButton(
                   icon: Icon(
                     Icons.filter_alt,
-                    color: shoppingList.shopFilterApplied
+                    color: shoppingListManager.isShopFilterApplied
                         ? Colors.black
                         : Colors.deepOrange[900],
                   ),
                   itemBuilder: (BuildContext context) =>
-                      shoppingList.availableShops
+                      shoppingListManager.availableShops
                           .map((e) => PopupMenuItem(
                                 child: Text(e),
                                 value: e,
@@ -303,13 +317,13 @@ class _HomeScreenState extends State<HomeScreen> {
                               value: '~',
                             )),
                   onSelected: setShopFilter,
-                  initialValue: shoppingList.filteredShop,
+                  initialValue: shoppingListManager.filteredShop,
                 ),
               ],
       ),
       body: getBody(),
       floatingActionButton: Visibility(
-        visible: isDataReady,
+        visible: isFirstLoadDone,
         child: FloatingActionButton(
           onPressed: addProductFunc,
           child: Icon(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -248,7 +248,7 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       drawer: MainDrawer(),
       appBar: AppBar(
-        title: Text('Lista Zakupów'),
+        title: Text('Lista zakupów'),
         actions: !isDataReady
             ? []
             : <Widget>[

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -24,12 +24,15 @@ class _HomeScreenState extends State<HomeScreen> {
   Product? editedProduct;
   bool isAddingProduct = false;
 
+  final animatedListKey = GlobalKey<AnimatedListState>();
+
   void addProductFunc() {
     if (!isAddingProduct) {
-      setState(() {
-        editedProduct = null;
-        isAddingProduct = true;
-      });
+        setState(() {
+          editedProduct = null;
+          isAddingProduct = true;
+        });
+        animatedListKey.currentState?.insertItem(0);
     }
   }
 
@@ -205,10 +208,18 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scrollbar(
       child: Provider<ShoppingList>(
         create: (context) => shoppingList,
-        child: ListView.builder(
+        child: AnimatedList(
+          key: animatedListKey,
           padding: EdgeInsets.all(5.0),
-          itemCount: itemsToDisplay.length,
-          itemBuilder: (context, index) => itemsToDisplay[index],
+          initialItemCount: itemsToDisplay.length,
+          itemBuilder: (context, index, animation) => SizeTransition(
+            sizeFactor: animation,
+            axisAlignment: 1,
+            child: Container(
+              width: double.infinity, // otherwise cards shrink in width
+              child: itemsToDisplay[index],
+            ),
+          ),
         ),
       ),
     );
@@ -233,7 +244,9 @@ class _HomeScreenState extends State<HomeScreen> {
       // on new products refresh the view as well as update isDataReady flag
       // on default shops received refresh the view so that the filters work
       shoppingList.startListening(
-        onProductsUpdatedCallback: () => setState(() => isDataReady = true),
+        onProductsUpdatedCallback: () {
+          if (!isDataReady) setState(() => isDataReady = true);
+        },
         onDefaultShopsReveivedCallback: () => setState(() {}),
       );
     }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -233,13 +233,10 @@ class _HomeScreenState extends State<HomeScreen> {
     // a circular progress indicator
     if (!isFirstLoadDone) return Center(child: CircularProgressIndicator());
 
-    // if data is ready, but there are no items to display, show an info on it
-    if (itemsToDisplay.isEmpty)
-      return Center(
-          child: Text(
-        'Brak przedmiotów do wyświetlenia',
-        textAlign: TextAlign.center,
-      ));
+    // for content shown if itemsToDisplay.isEmpty
+    final screenHeight = MediaQuery.of(context).size.height;
+    final padding = MediaQuery.of(context).viewPadding;
+    final viewHeight = screenHeight - padding.top - kToolbarHeight;
 
     // otherwise, display the shopping list
     return Provider<ShoppingListManager>(
@@ -267,6 +264,17 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
             ),
           ),
+          if (itemsToDisplay.isEmpty)
+            SliverToBoxAdapter(
+              child: Container(
+                height: viewHeight,
+                child: Center(
+                    child: Text(
+                  'Brak przedmiotów do wyświetlenia',
+                  textAlign: TextAlign.center,
+                )),
+              ),
+            ),
         ],
       ),
     );

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -134,12 +134,25 @@ class _HomeScreenState extends State<HomeScreen> {
 
     // handle adding product
     if (isAddingProduct) {
-      // adding product key
-      final productCard = ProductCard.emptyEditor(
-          newProductId: Product.generateProductId(),
-          onConfirmEdit: confirmEditProductFunc,
-          onCancelEdit: cancelEditProductFunc);
-      result.insert(0, productCard);
+      final defaults = Product(
+        // default values for editor
+        id: Product.generateProductId(),
+        name: '',
+        dateAdded: DateTime.now(),
+        whoAdded: SM.getUsername(),
+        // set shop by default if filter active
+        shop: shoppingListManager.isShopFilterApplied
+            ? shoppingListManager.filteredShop
+            : null,
+        // set buyer by default if filter active
+        buyer: shoppingListManager.showOnlyDeclaredByUser
+            ? SM.getUsername()
+            : null,
+        quantity: 1,
+        quantityUnit: 'szt',
+      );
+      final addProductCard = wrapProductWithWidget(defaults, isEditing: true);
+      result.insert(0, addProductCard);
     }
     // handle editing product
     else if (editedProduct != null) {

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -203,9 +203,10 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scrollbar(
       child: Provider<ShoppingList>(
         create: (context) => shoppingList,
-        builder: (context, child) => ListView(
-          children: itemsToDisplay,
+        child: ListView.builder(
           padding: EdgeInsets.all(5.0),
+          itemCount: itemsToDisplay.length,
+          itemBuilder: (context, index) => itemsToDisplay[index],
         ),
       ),
     );

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -111,6 +111,7 @@ class _HomeScreenState extends State<HomeScreen> {
     setState(() {
       // cancel editing when filters change
       editedProduct = null;
+      isAddingProduct = false;
       // toggle filter
       shoppingList.showOnlyDeclaredByUser =
           !shoppingList.showOnlyDeclaredByUser;
@@ -121,6 +122,7 @@ class _HomeScreenState extends State<HomeScreen> {
     setState(() {
       // cancel editing when filters change
       editedProduct = null;
+      isAddingProduct = false;
       // apply filter
       shoppingList.filteredShop = filter;
     });

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -149,7 +149,7 @@ class _HomeScreenState extends State<HomeScreen> {
             ? SM.getUsername()
             : null,
         quantity: 1,
-        quantityUnit: 'szt',
+        quantityUnit: 'szt.',
       );
       final addProductCard = wrapProductWithWidget(defaults, isEditing: true);
       result.insert(0, addProductCard);

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -5,6 +5,7 @@ import 'package:zakupyapp/core/updater.dart';
 import 'package:zakupyapp/storage/storage_manager.dart';
 import 'package:zakupyapp/utils/app_info.dart';
 import 'package:zakupyapp/widgets/drawer/main_drawer.dart';
+import 'package:zakupyapp/widgets/settings/settings_group_title.dart';
 
 import '../widgets/shared/update_dialog.dart';
 
@@ -89,7 +90,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ));
   }
 
-  Future<void> showUpdateDialog() async {
+  /// Clicking the version label in debug model will cause
+  /// update dialog to pop up
+  Future<void> handleClickVersionLabel() async {
+    if (!kDebugMode) {
+      return;
+    }
     final latestRelease = await Updater().getLatestRelease();
     await showDialog(
       context: context,
@@ -107,8 +113,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
         title: Text('Ustawienia'),
       ),
       body: ListView(
-        padding: EdgeInsets.only(top: 5),
+        padding: EdgeInsets.only(top: 8),
         children: <Widget>[
+          SettingsGroupTitle(titleText: 'Lista zakupów'),
           ListTile(
             title: Text('ID Listy zakupów'),
             subtitle:
@@ -132,22 +139,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
           SwitchListTile(
             title: Text(
-              'Aktualizuj za pomocą Family Store',
-              style: TextStyle(
-                color: Colors.black,
-              ),
-            ),
-            secondary: Icon(
-              Icons.update,
-              color: Colors.black,
-            ),
-            value: SM.getUseFamilyStore(),
-            onChanged: (value) => setState(() {
-              SM.setUseFamilyStore(value);
-            }),
-          ),
-          SwitchListTile(
-            title: Text(
               'Ukrywaj produkty zadeklarowane przez innych',
               style: TextStyle(
                 color: Colors.black,
@@ -162,6 +153,23 @@ class _SettingsScreenState extends State<SettingsScreen> {
               SM.setHideProductsOthersDeclared(newValue);
             }),
           ),
+          SettingsGroupTitle(titleText: 'Aktualizacje'),
+          SwitchListTile(
+            title: Text(
+              'Aktualizuj za pomocą Family Store',
+              style: TextStyle(
+                color: Colors.black,
+              ),
+            ),
+            secondary: Icon(
+              Icons.update,
+              color: Colors.black,
+            ),
+            value: SM.getUseFamilyStore(),
+            onChanged: (value) => setState(() {
+              SM.setUseFamilyStore(value);
+            }),
+          ),
           ListTile(
             title: Text('Wersja aplikacji'),
             subtitle: Text(AppInfo.getVersion()),
@@ -170,7 +178,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               color: Colors.black,
             ),
             titleAlignment: ListTileTitleAlignment.center,
-            onTap: kDebugMode ? () async => await showUpdateDialog() : null,
+            onTap: handleClickVersionLabel,
           ),
         ],
       ),

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -170,9 +170,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               color: Colors.black,
             ),
             titleAlignment: ListTileTitleAlignment.center,
-            onTap: () async {
-               await showUpdateDialog();
-            },
+            onTap: kDebugMode ? () async => await showUpdateDialog() : null,
           ),
         ],
       ),

--- a/lib/storage/storage_manager.dart
+++ b/lib/storage/storage_manager.dart
@@ -1,4 +1,5 @@
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:zakupyapp/constants.dart';
 
 class SM {
   static late SharedPreferences _storage;
@@ -19,12 +20,12 @@ class SM {
   }
 
   static String getUsername() {
-    return _storage.getString('username') ?? 'Użytkownik bez nazwy';
+    return _storage.getString('username') ?? Constants.DEFAULT_USERNAME;
   }
 
   static void setUsername(String username) {
     if (username == '') {
-      username = 'Użytkownik bez nazwy';
+      username = Constants.DEFAULT_USERNAME;
     }
     _storage.setString('username', username.trim());
   }

--- a/lib/widgets/drawer/main_drawer.dart
+++ b/lib/widgets/drawer/main_drawer.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:zakupyapp/constants.dart';
 
 import 'package:zakupyapp/widgets/drawer/help_dialog.dart';
 
@@ -15,6 +17,11 @@ class MainDrawer extends StatelessWidget {
 
   Future<void> showHelpDialog(BuildContext context) async {
     await showDialog(context: context, builder: (ctx) => HelpDialog());
+  }
+
+  Future<void> viewInFamilyStore() async {
+    Uri uri = Uri.parse(Constants.FAMILY_STORE_URL);
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
   }
 
   @override
@@ -49,6 +56,12 @@ class MainDrawer extends StatelessWidget {
           leading: Icon(Icons.help),
           title: Text('Pomoc'),
           onTap: () async => await showHelpDialog(context),
+        ),
+        ListTile(
+          // settings
+          leading: Icon(Icons.launch),
+          title: Text('Wyświetl aplikację w Family Store'),
+          onTap: viewInFamilyStore,
         ),
       ],
     ));

--- a/lib/widgets/home/product_card/product_card.dart
+++ b/lib/widgets/home/product_card/product_card.dart
@@ -5,29 +5,50 @@ import 'package:zakupyapp/widgets/home/product_card/product_card_content.dart';
 import 'package:zakupyapp/widgets/home/product_card/product_editor.dart';
 
 class ProductCard extends StatelessWidget {
+  /// null if a new product is being added
   final Product? product;
+
+  /// not null only if a new product is being added
+  final String? newProductId;
 
   // product card content
   final VoidCallback editFunc;
-  final VoidCallback deleteFunc;
+  final void Function(Product) deleteFunc;
   final VoidCallback addBuyerFunc;
 
   // product editor
   final void Function(Product product) onConfirmEdit;
-  final VoidCallback onCancelEdit;
+  final void Function() onCancelEdit;
 
   final bool isEditing;
 
-  const ProductCard(
-      {Key? key,
-      required this.product,
-      required this.editFunc,
-      required this.deleteFunc,
-      required this.addBuyerFunc,
-      required this.onConfirmEdit,
-      required this.onCancelEdit,
-      this.isEditing = false})
-      : super(key: key);
+  const ProductCard({
+    Key? key,
+    required this.product,
+    required this.editFunc,
+    required this.deleteFunc,
+    required this.addBuyerFunc,
+    required this.onConfirmEdit,
+    required this.onCancelEdit,
+    this.isEditing = false,
+    this.newProductId = null,
+  }) : super(key: key);
+
+  ProductCard.emptyEditor({
+    required String newProductId,
+    required void Function(Product product) onConfirmEdit,
+    required void Function() onCancelEdit,
+  }) : this(
+          key: Key(newProductId),
+          product: null,
+          editFunc: () {},
+          deleteFunc: (p) {},
+          addBuyerFunc: () {},
+          onConfirmEdit: onConfirmEdit,
+          onCancelEdit: onCancelEdit,
+          isEditing: true,
+          newProductId: newProductId,
+        );
 
   Color? get cardColor {
     // default or when adding a product
@@ -46,34 +67,65 @@ class ProductCard extends StatelessWidget {
     return Colors.orange[50];
   }
 
+  Future<void> showDeleteDialog(BuildContext context) async {
+    await showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('Usuń produkt'),
+          content: Text('Czy na pewno chcesz usunąć: ${product!.name}?'),
+          actions: <Widget>[
+            TextButton(
+              child: Text('Anuluj'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: Text('Tak'),
+              onPressed: () {
+                Navigator.of(context).pop();
+                deleteFunc(product!);
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Card(
-      color: cardColor,
-      child: InkWell(
-        onTap: isEditing ? null : deleteFunc,
-        onDoubleTap: isEditing ? null : addBuyerFunc,
-        onLongPress: isEditing ? null : editFunc,
-        child: AnimatedSize(
-          duration: Duration(milliseconds: 250),
-          alignment: Alignment.topCenter,
-          child: isEditing
-              ? Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
-                  child: ProductEditor(
-                    product: product,
-                    onConfirmEdit: onConfirmEdit,
-                    onCancelEdit: onCancelEdit,
+    return Container(
+      width: double.infinity, // otherwise cards shrink in width
+      child: Card(
+        color: cardColor,
+        child: InkWell(
+          onTap: isEditing ? null : () => showDeleteDialog(context),
+          onDoubleTap: isEditing ? null : addBuyerFunc,
+          onLongPress: isEditing ? null : editFunc,
+          child: AnimatedSize(
+            duration: Duration(milliseconds: 250),
+            alignment: Alignment.topCenter,
+            child: isEditing
+                ? Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                    child: ProductEditor(
+                      product: product,
+                      newProductId: newProductId,
+                      onConfirmEdit: onConfirmEdit,
+                      onCancelEdit: onCancelEdit,
+                    ),
+                  )
+                : AnimatedSize(
+                    duration: Duration(milliseconds: 250),
+                    alignment: Alignment.bottomCenter,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: ProductCardContent(product: product!),
+                    ),
                   ),
-                )
-              : AnimatedSize(
-                  duration: Duration(milliseconds: 250),
-                  alignment: Alignment.bottomCenter,
-                  child: Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: ProductCardContent(product: product!),
-                  ),
-                ),
+          ),
         ),
       ),
     );

--- a/lib/widgets/home/product_card/product_card.dart
+++ b/lib/widgets/home/product_card/product_card.dart
@@ -5,11 +5,7 @@ import 'package:zakupyapp/widgets/home/product_card/product_card_content.dart';
 import 'package:zakupyapp/widgets/home/product_card/product_editor.dart';
 
 class ProductCard extends StatelessWidget {
-  /// null if a new product is being added
-  final Product? product;
-
-  /// not null only if a new product is being added
-  final String? newProductId;
+  final Product product;
 
   // product card content
   final VoidCallback editFunc;
@@ -31,36 +27,19 @@ class ProductCard extends StatelessWidget {
     required this.onConfirmEdit,
     required this.onCancelEdit,
     this.isEditing = false,
-    this.newProductId = null,
   }) : super(key: key);
 
-  ProductCard.emptyEditor({
-    required String newProductId,
-    required void Function(Product product) onConfirmEdit,
-    required void Function() onCancelEdit,
-  }) : this(
-          key: Key(newProductId),
-          product: null,
-          editFunc: () {},
-          deleteFunc: (p) {},
-          addBuyerFunc: () {},
-          onConfirmEdit: onConfirmEdit,
-          onCancelEdit: onCancelEdit,
-          isEditing: true,
-          newProductId: newProductId,
-        );
-
   Color? get cardColor {
-    // default or when adding a product
-    if (product == null || product?.buyer == null) {
+    // undeclared
+    if (product.buyer == null) {
       return Colors.orange[100];
     }
     // declared by user and not editing
-    if (product!.isDeclaredByUser && !isEditing) {
+    if (product.isDeclaredByUser && !isEditing) {
       return Colors.orange[300];
     }
     // declared by user but editing
-    if (product!.isDeclaredByUser && isEditing) {
+    if (product.isDeclaredByUser && isEditing) {
       return Colors.orange[200];
     }
     // declared by someone else
@@ -73,7 +52,7 @@ class ProductCard extends StatelessWidget {
       builder: (context) {
         return AlertDialog(
           title: Text('Usuń produkt'),
-          content: Text('Czy na pewno chcesz usunąć: ${product!.name}?'),
+          content: Text('Czy na pewno chcesz usunąć: ${product.name}?'),
           actions: <Widget>[
             TextButton(
               child: Text('Anuluj'),
@@ -85,7 +64,7 @@ class ProductCard extends StatelessWidget {
               child: Text('Tak'),
               onPressed: () {
                 Navigator.of(context).pop();
-                deleteFunc(product!);
+                deleteFunc(product);
               },
             ),
           ],
@@ -112,7 +91,6 @@ class ProductCard extends StatelessWidget {
                     padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
                     child: ProductEditor(
                       product: product,
-                      newProductId: newProductId,
                       onConfirmEdit: onConfirmEdit,
                       onCancelEdit: onCancelEdit,
                     ),
@@ -122,7 +100,7 @@ class ProductCard extends StatelessWidget {
                     alignment: Alignment.bottomCenter,
                     child: Padding(
                       padding: const EdgeInsets.all(16),
-                      child: ProductCardContent(product: product!),
+                      child: ProductCardContent(product: product),
                     ),
                   ),
           ),

--- a/lib/widgets/home/product_card/product_editor.dart
+++ b/lib/widgets/home/product_card/product_editor.dart
@@ -35,7 +35,7 @@ class _ProductEditorState extends State<ProductEditor> {
   Deadline? get _selectedDeadline =>
       _selectedDay == null ? null : Deadline(_selectedDay!);
   double _selectedQuantity = 1;
-  String _selectedQuantityUnit = 'szt.';
+  String _selectedQuantityUnit = '';
 
   String? productNameValidator(String? productName) {
     if (productName!.isEmpty) return 'Pole nie może być puste';

--- a/lib/widgets/home/product_card/product_editor.dart
+++ b/lib/widgets/home/product_card/product_editor.dart
@@ -3,25 +3,19 @@ import 'package:provider/provider.dart';
 import 'package:zakupyapp/core/models/deadline.dart';
 import 'package:zakupyapp/core/models/product.dart';
 import 'package:zakupyapp/core/shopping_list_manager.dart';
-import 'package:zakupyapp/storage/storage_manager.dart';
 import 'package:zakupyapp/widgets/home/product_card/product_detail_editor_chip.dart';
 import 'package:zakupyapp/widgets/home/product_card/select_quantity_dialog.dart';
 import 'package:zakupyapp/widgets/home/product_card/select_shop_dialog.dart';
 
 class ProductEditor extends StatefulWidget {
-  /// null if a new product is being added
-  final Product? product;
-
-  /// not null only if a new product is being added
-  final String? newProductId;
+  final Product product;
 
   final void Function(Product product) onConfirmEdit;
   final VoidCallback onCancelEdit;
 
   const ProductEditor(
       {super.key,
-      this.product,
-      this.newProductId,
+      required this.product,
       required this.onConfirmEdit,
       required this.onCancelEdit});
 
@@ -35,7 +29,6 @@ class _ProductEditorState extends State<ProductEditor> {
 
   final _productNameFocusNode = FocusNode(canRequestFocus: false);
 
-  String _productId = '';
   String _productName = '';
   String _selectedShop = '';
   DateTime? _selectedDay;
@@ -104,16 +97,14 @@ class _ProductEditorState extends State<ProductEditor> {
 
   void confirmEdit() {
     if (_formKey.currentState!.validate()) {
-      final productDateAdded =
-          widget.product == null ? DateTime.now() : widget.product!.dateAdded;
       final newProduct = Product(
-        id: _productId,
+        id: widget.product.id,
         name: _productName,
-        dateAdded: productDateAdded,
-        whoAdded: SM.getUsername(),
+        dateAdded: widget.product.dateAdded,
+        whoAdded: widget.product.whoAdded,
         shop: _selectedShop == '' ? null : _selectedShop,
         deadline: _selectedDeadline,
-        buyer: widget.product?.buyer,
+        buyer: widget.product.buyer,
         quantity: _selectedQuantity,
         quantityUnit: _selectedQuantityUnit,
       );
@@ -128,19 +119,14 @@ class _ProductEditorState extends State<ProductEditor> {
   @override
   void initState() {
     super.initState();
-    // get shop and quantity units lists
+    // provider for shop and quantity units lists
     _provider = Provider.of<ShoppingListManager>(context, listen: false);
-    // if editing
-    if (widget.product != null) {
-      _productId = widget.product!.id;
-      _productName = widget.product!.name;
-      _selectedShop = widget.product!.shop ?? '';
-      _selectedDay = widget.product!.deadline?.deadlineDay;
-      _selectedQuantity = widget.product!.quantity;
-      _selectedQuantityUnit = widget.product!.quantityUnit;
-    } else {
-      _productId = widget.newProductId!;
-    }
+    // default values for editor
+    _productName = widget.product.name;
+    _selectedShop = widget.product.shop ?? '';
+    _selectedDay = widget.product.deadline?.deadlineDay;
+    _selectedQuantity = widget.product.quantity;
+    _selectedQuantityUnit = widget.product.quantityUnit;
   }
 
   @override
@@ -161,7 +147,7 @@ class _ProductEditorState extends State<ProductEditor> {
             ),
             style: TextStyle(fontSize: 18),
             validator: productNameValidator,
-            autofocus: widget.product == null,
+            autofocus: widget.product.name == '',
             focusNode: _productNameFocusNode,
           ),
 

--- a/lib/widgets/settings/settings_group_title.dart
+++ b/lib/widgets/settings/settings_group_title.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class SettingsGroupTitle extends StatelessWidget {
+  final String titleText;
+
+  const SettingsGroupTitle({super.key, required this.titleText});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(titleText),
+      titleTextStyle: TextStyle(
+        color: Theme.of(context).primaryColor,
+        fontWeight: FontWeight.bold,
+        fontSize: 13,
+      ),
+      leading: const SizedBox(width: 0, height: 0),
+      dense: true,
+      contentPadding: EdgeInsets.fromLTRB(16, 4, 16, 0),
+      onTap: null,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  diffutil_dart:
+    dependency: transitive
+    description:
+      name: diffutil_dart
+      sha256: e0297e4600b9797edff228ed60f4169a778ea357691ec98408fa3b72994c7d06
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  diffutil_sliverlist:
+    dependency: "direct main"
+    description:
+      name: diffutil_sliverlist
+      sha256: d20d7d521506b24190846cdbb6007e1b86fc0c26f04419cf359e426890911593
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   test: ^1.24.3
   url_launcher: ^6.1.14
   provider: ^6.0.5
+  diffutil_sliverlist: ^0.5.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zakupyapp
 description: Lista zakupowa
-version: 1.5.1  # updated 14/09/2023
+version: 1.5.2  # updated 17/09/2023
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/test/core/models/deadline_test.dart
+++ b/test/core/models/deadline_test.dart
@@ -9,22 +9,22 @@ void main() {
     test('yesterday is too late', () {
       var deadline = Deadline(today.subtract(Duration(days: 1)));
       var result = Urgency.too_late;
-      expect(deadline.getUrgency(), result);
+      expect(deadline.getUrgency(), equals(result));
     });
     test('exact day is urgent', () {
       var deadline = Deadline(today);
       var result = Urgency.urgent;
-      expect(deadline.getUrgency(), result);
+      expect(deadline.getUrgency(), equals(result));
     });
     test('tomorrow is urgent', () {
       var deadline = Deadline(today.add(Duration(days: 1)));
       var result = Urgency.urgent;
-      expect(deadline.getUrgency(), result);
+      expect(deadline.getUrgency(), equals(result));
     });
     test('in two days is not urgent', () {
       var deadline = Deadline(today.add(Duration(days: 2)));
       var result = Urgency.not_urgent;
-      expect(deadline.getUrgency(), result);
+      expect(deadline.getUrgency(), equals(result));
     });
   });
 
@@ -32,37 +32,53 @@ void main() {
     test('deadline more than two days ago', () {
       var deadline = Deadline(today.subtract(Duration(days: 3)));
       var result = '3 dni temu';
-      expect(deadline.getPolishDescription(), result);
+      expect(deadline.getPolishDescription(), equals(result));
     });
     test('deadline two days ago', () {
       var deadline = Deadline(today.subtract(Duration(days: 2)));
       var result = 'przedwczoraj';
-      expect(deadline.getPolishDescription(), result);
+      expect(deadline.getPolishDescription(), equals(result));
     });
     test('deadline yesterday', () {
       var deadline = Deadline(today.subtract(Duration(days: 1)));
       var result = 'wczoraj';
-      expect(deadline.getPolishDescription(), result);
+      expect(deadline.getPolishDescription(), equals(result));
     });
     test('deadline today', () {
       var deadline = Deadline(today);
       var result = 'dzisiaj';
-      expect(deadline.getPolishDescription(), result);
+      expect(deadline.getPolishDescription(), equals(result));
     });
     test('deadline tomorrow', () {
       var deadline = Deadline(today.add(Duration(days: 1)));
       var result = 'jutro';
-      expect(deadline.getPolishDescription(), result);
+      expect(deadline.getPolishDescription(), equals(result));
     });
     test('deadline in two days', () {
       var deadline = Deadline(today.add(Duration(days: 2)));
       var result = 'pojutrze';
-      expect(deadline.getPolishDescription(), result);
+      expect(deadline.getPolishDescription(), equals(result));
     });
     test('deadline in more than two days', () {
       var deadline = Deadline(today.add(Duration(days: 3)));
       var result = 'za 3 dni';
-      expect(deadline.getPolishDescription(), result);
+      expect(deadline.getPolishDescription(), equals(result));
+    });
+  });
+
+  group('Deadline.parse() tests', () {
+    test('Deadline can parse its string representation', () {
+      var date = DateTime(2023, 9, 17);
+      var deadline = Deadline(date);
+      String stringRepr = deadline.toString();
+      var parsedDeadline = Deadline.parse(stringRepr);
+      expect(parsedDeadline.deadlineDay, equals(date));
+    });
+    test('old deadline format is correctly parsed', () {
+      String oldFormat = '2023-09-13 00:00:00.000|true';
+      var parsedDeadline = Deadline.parse(oldFormat);
+      var expectedDate = DateTime(2023, 09, 13);
+      expect(parsedDeadline.deadlineDay, equals(expectedDate));
     });
   });
 }


### PR DESCRIPTION
- Split settings into groups
- add a button to the drawer that views the app in Family Store
- replace regular ListView with an animated list
- make it so that when adding a product when filters are active, the filters carry on as default values for product fields (i.e. if buyer filter is active, the user will be the product buyer by default, same with the shop filter)