### PR TITLE
1.5.2 rerelease

### DIFF
--- a/lib/core/updater.dart
+++ b/lib/core/updater.dart
@@ -25,9 +25,8 @@ class Updater {
   Future<void> checkForUpdate(void Function(AppRelease release)? updateAvailableCallback) async {
     // don't perform any action if any of the following is true:
     // - this instance of Updater has already checked for update
-    // - updates are turned off
     // - application was compiled in debug mode
-    if (_checkedForUpdate || !SM.getUseFamilyStore() || kDebugMode) {
+    if (_checkedForUpdate || kDebugMode) {
       return;
     }
     _checkedForUpdate = true;

--- a/test/core/models/apprelease_test.dart
+++ b/test/core/models/apprelease_test.dart
@@ -2,15 +2,25 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zakupyapp/core/models/apprelease.dart';
 
 void main() {
-  test('getMaxVersion() correctly returns the latest version ID', () {
-    var filenames = [
-      'zakupyapp-1.99.0.apk',
-      'zakupyapp-1.3.199.apk',
-      'zakupyapp-2.100.0.apk',
-      'zakupyapp-2.2.99.apk'
-    ];
-    String latest = '2.100.0';
-    expect(AppRelease.getMaxVersion(filenames), equals(latest));
+  group('getMaxVersion() correctly returns the latest version ID', () {
+    test('Case 1', () {
+      var filenames = [
+        'zakupyapp-1.99.0.apk',
+        'zakupyapp-1.3.199.apk',
+        'zakupyapp-2.100.0.apk',
+        'zakupyapp-2.2.99.apk',
+      ];
+      String latest = '2.100.0';
+      expect(AppRelease.getMaxVersion(filenames), equals(latest));
+    });
+    test('Case 2', () {
+      var filenames = [
+        'zakupyapp-1.5.2.apk',
+        'zakupyapp-1.5.0.apk',
+      ];
+      String latest = '1.5.2';
+      expect(AppRelease.getMaxVersion(filenames), equals(latest));
+    });
   });
 
   group('compareTo() correcly compares app versions', () {


### PR DESCRIPTION
hotfix of a critical issue: update dialog not showing up when using legacy update source (not family store)